### PR TITLE
Add loading recorded games to agents memory + small refactor + stats …

### DIFF
--- a/MemoryLoader.py
+++ b/MemoryLoader.py
@@ -1,0 +1,113 @@
+import os
+import sys
+from rl.memory import Memory
+from SokobanEnv import SokobanEnv
+from SokobanGame import SokobanGame
+
+
+class SokobanManualGameMemoryLoader:
+    DEFAULT_PATH_TO_GAMES = 'manual_games_to_load/'
+    MOVE_SEPARATOR = ';'
+
+    def __init__(self, agent_memory: Memory, memory_limit: int, path_to_games: str = DEFAULT_PATH_TO_GAMES,
+                 is_map_in_center: bool = True, do_scale_rewards: bool = False, do_scale_env: bool = False):
+        """ memory_linit means how many moves you want to load into agent memory """
+        self.agent_memory = agent_memory
+        self.memory_limit = memory_limit
+        self.path_to_games = path_to_games
+        self.is_map_in_center = is_map_in_center
+        self.do_scale_rewards = do_scale_rewards
+        self.do_scale_env = do_scale_env
+
+    def get_env_for_current_file(self, map_name: str, map_rotation: int):
+        env = SokobanEnv(
+            game_timeout=SokobanGame.DEFAULT_TIMEOUT,
+            put_map_in_the_center=self.is_map_in_center,
+            info_game_count=500,    # this will never be used in this case
+            use_bugged_dict_entries=False,
+            save_file_name='test_DQN_game_',    # this will never be used in this case
+            save_every_game_to_file=False,  # it would be pointless to save already saved game...
+            map_choice_option=SokobanEnv.USE_SINGLE_SPECIFIED_MAP,
+            use_more_than_one_channel=False,    # current implementation does NOT support window_length != 1
+            scale_rewards=self.do_scale_rewards,
+            scale_range=(-1, 1),
+            use_scaled_env_representation=self.do_scale_env,
+            disable_map_rotation=False,     # has to be false because we manually set rotation
+            specific_map=map_name,
+            use_specific_rotation=True,     # we must specify rotation from file
+            specific_rotation=map_rotation
+        )
+
+        return env
+
+    def load_all_games(self):
+        move_counter = 0
+        is_memory_full = False
+
+        # load moves into agents memory until specified limit is reached
+        while not is_memory_full:
+            for file in os.listdir(self.path_to_games):
+                print('Loading file ' + file)
+                map_name, moves, _, _, map_rotation = SokobanGame.get_game_from_file(self.path_to_games + file)
+
+                if not map_rotation.isdigit():
+                    print("Invalid map rotation! - not a number - skipping")
+                    continue
+                map_rotation = int(map_rotation)
+                map_name = map_name.split('/')[1]   # extract only map name without 'levels/'
+
+                try:
+                    # prepare env
+                    sokoban_env_for_this_game = self.get_env_for_current_file(map_name, map_rotation)
+                    env_for_current_move = sokoban_env_for_this_game.reset()    # get first env state
+
+                    # process every move from file
+                    move_list = moves.split(self.MOVE_SEPARATOR)
+                    for move in move_list:
+                        # check if memory is full - it would be a waste of time to continue loading when memory is already full
+                        move_counter += 1
+                        if move_counter == self.memory_limit:
+                            is_memory_full = True
+                            break
+
+                        # first translate action to numerical one used by env step(...) method
+                        if move in SokobanEnv.WASD_TO_ACTIONS:
+                            env_move = SokobanEnv.WASD_TO_ACTIONS[move]
+                        elif move in SokobanEnv.LRUD_TO_ACTIONS:
+                            env_move = SokobanEnv.LRUD_TO_ACTIONS[move]
+                        else:
+                            print("Invalid move: " + str(move) + " file: " + file + " - skipping")
+                            continue
+
+                        # process step with env
+                        env_state, reward_for_this_step, game_done, step_info_dict = sokoban_env_for_this_game.step(env_move)
+
+                        # append move to agents memory
+                        # according to Memory of keras-rl:
+                        # "This needs to be understood as follows: in `observation`, take `action`, obtain `reward`
+                        # and weather the next state is `terminal` or not."
+                        # and:
+                        # "This is to be understood as a transition: Given `state0`, performing `action`
+                        # yields `reward` and results in `state1`, which might be `terminal`."
+                        # So we need to append state before the move was made and later replace the old move with the one returned by env.step(...)
+
+                        # But in Memory.append(...) comment documentation there is:
+                        # "observation (dict): Observation returned by environment
+                        # action (int): Action taken to obtain this observation
+                        # reward (float): Reward obtained by taking this action
+                        # terminal (boolean): Is the state terminal"
+                        # So this can be wrong...
+                        self.agent_memory.append(env_for_current_move, env_move, reward_for_this_step, game_done, training=True)
+                        env_for_current_move = env_state
+
+                        if game_done:
+                            break
+
+                except ValueError:
+                    print("Invalid map specified in file " + file + ' - skipping')
+                    sys.exit(-1)
+                    continue
+
+                if is_memory_full:
+                    print("Done loading! Loaded " + str(move_counter) + " moves to agent memory")
+                    break

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Sokoban game with RL based playing
         contains basic example of working Deep Q Learning agent using SokobanEnv class as environment <br/>
         with basic statistics.
     <li>
+    TestDQN.py: <br/>
+        contains DQN agent used for testing different network architectures and parameters. <br/>
+    <li>
     DQNAgentUtils.py: <br/>
         contains common utility functions for DQN agents such as saving model summary and weights or plotting rewards <br/>
     <li>
@@ -31,4 +34,7 @@ Sokoban game with RL based playing
     <li>
     game_stats: <br/>
         short records of each game played by DQN a agent and eeven shorter summary of games on each map <br/>
+    <li>
+    MemoryLoader.py <br/>
+        ccontains class that allows loading saved games from files into agents memory
 <ul/>

--- a/SokobanGame.py
+++ b/SokobanGame.py
@@ -93,18 +93,6 @@ class SokobanGame:
     PATH_TO_LEVELS = 'levels/'
     PATH_TO_MANUAL_GAMES = 'manual_games/'
 
-    # instance variables
-    current_level = None
-    reward_system = None
-    move_counter = 0
-    total_reward = 0.0
-    moves_made = []
-    rewards_received = []
-    game_timeout = None
-    path_to_current_level = None
-    is_manual = None
-    map_rotation = None
-
     def __init__(self, path_to_level: str, reward_impl: AbstractRewardSystem, loss_timeout: int = DEFAULT_TIMEOUT,
                  manual_play: bool = True, map_rotation: int = MAP_ROTATION_NONE):
         """ Initializes single game. Requires path to file with level and a reward system (ex. basic RewardSystem()).
@@ -122,19 +110,15 @@ class SokobanGame:
         self.reward_system = reward_impl
         self.game_timeout = loss_timeout
         self.is_manual = manual_play
+        self.move_counter = 0
+        self.total_reward = 0.0
+        self.moves_made = []
+        self.rewards_received = []
         if map_rotation not in [self.MAP_ROTATION_NONE, self.MAP_ROTATION_90, self.MAP_ROTATION_180, self.MAP_ROTATION_270]:
             raise Exception("Invalid map rotation option!")
         self.map_rotation = map_rotation
         # rotate map according to setting
         self.current_level = np.rot90(self.current_level, k=map_rotation)
-
-        self.reinitialize_stats_variables()
-
-    def reinitialize_stats_variables(self):
-        self.move_counter = 0
-        self.total_reward = 0.0
-        self.moves_made = []
-        self.rewards_received = []
 
     @staticmethod
     def get_level(filepath: str):
@@ -426,6 +410,23 @@ class SokobanGame:
             f.write(str(self.map_rotation))
 
         return filename
+
+    @staticmethod
+    def get_game_from_file(file_name: str):
+        with open(file_name, "r") as f:
+            read_lines = f.readlines()
+
+        # use rstrip() to remove new line characters at the end of strings read by f.readlines()
+        map_name = read_lines[0].rstrip()
+        moves = read_lines[1].rstrip()
+        rewards = read_lines[2].rstrip()
+        total_reward = read_lines[3].rstrip()
+        if len(read_lines) > 4:
+            map_rotation = read_lines[4].rstrip()
+        else:   # if rotation not specified assume that there is no rotation
+            map_rotation = SokobanGame.MAP_ROTATION_NONE
+
+        return map_name, moves, rewards, total_reward, map_rotation
 
     def check_and_process_game_end(self, save_record_to_file: bool = True):
         """ To be called after making move, returns True if game is over, False if it is not and returns final reward - 0 if not game over yet  """


### PR DESCRIPTION
…change

Memory loader allowing adding already played games to be loaded into agents memory.
Refactor of class/instance variables in SokobanGame and SokobanEnv.
Add some options to TestDQN.
Change stats map names - now map rotation is included in map name used for stats.

Signed-off-by: godemperor785 <godemperor785@gmail.com>